### PR TITLE
Add SQLite storage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # hello-world
+
 Repositorio de ideas
 
 Es hora de probar git hub
+
+## Guardar mensajes en una base de datos
+
+Este repositorio incluye un script en Python llamado `save_to_db.py` que
+permite almacenar cualquier texto en una base de datos SQLite llamada
+`data.db`.
+
+### Uso
+
+Ejecute el siguiente comando para guardar un mensaje:
+
+```bash
+python3 save_to_db.py "Su mensaje aqui"
+```
+
+El mensaje se almacenará en la tabla `messages` dentro de `data.db`.

--- a/save_to_db.py
+++ b/save_to_db.py
@@ -1,0 +1,22 @@
+import sqlite3
+import sys
+
+
+def save_message(db_path, message):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, message TEXT)"
+    )
+    cur.execute("INSERT INTO messages (message) VALUES (?)", (message,))
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        msg = " ".join(sys.argv[1:])
+    else:
+        msg = input("Ingrese el mensaje a guardar: ")
+    save_message("data.db", msg)
+    print("Mensaje guardado en la base de datos.")


### PR DESCRIPTION
## Summary
- add a Python script to store messages in `data.db`
- document usage in README
- ignore database and Python cache files

## Testing
- `python3 -m py_compile save_to_db.py`
- `python3 save_to_db.py "mensaje de prueba"`
- `sqlite3 data.db "SELECT * FROM messages;"`

------
https://chatgpt.com/codex/tasks/task_e_683fc6a4671c832e9ebfc73c56d0ec98